### PR TITLE
Renamed select mode to noproxy mode...

### DIFF
--- a/adl/config.adl
+++ b/adl/config.adl
@@ -24,7 +24,7 @@ struct ToolConfig {
     BlobStoreConfig releases;
 
     Vector<DeployContext> deployContexts;
-    DeployMode deployMode = "select";
+    DeployMode deployMode = "noproxy";
 
     // Support for AWS health checks in proxy mode
     Maybe<HealthCheckConfig> healthCheck = { "just": {
@@ -34,7 +34,7 @@ struct ToolConfig {
 };
 
 union DeployMode {
-   Void select;
+   Void noproxy;
    ProxyModeConfig proxy;
 };
 

--- a/src/ADL/Config.hs
+++ b/src/ADL/Config.hs
@@ -89,7 +89,7 @@ instance AdlValue DeployContextSource where
         <|> parseFail "expected a DeployContextSource"
 
 data DeployMode
-    = DeployMode_select
+    = DeployMode_noproxy
     | DeployMode_proxy ProxyModeConfig
     deriving (Prelude.Eq,Prelude.Ord,Prelude.Show)
 
@@ -97,12 +97,12 @@ instance AdlValue DeployMode where
     atype _ = "config.DeployMode"
     
     jsonGen = genUnion (\jv -> case jv of
-        DeployMode_select -> genUnionVoid "select"
+        DeployMode_noproxy -> genUnionVoid "noproxy"
         DeployMode_proxy v -> genUnionValue "proxy" v
         )
     
     jsonParser
-        =   parseUnionVoid "select" DeployMode_select
+        =   parseUnionVoid "noproxy" DeployMode_noproxy
         <|> parseUnionValue "proxy" DeployMode_proxy
         <|> parseFail "expected a DeployMode"
 
@@ -305,7 +305,7 @@ data ToolConfig = ToolConfig
     deriving (Prelude.Eq,Prelude.Ord,Prelude.Show)
 
 mkToolConfig :: BlobStoreConfig -> [DeployContext] -> ToolConfig
-mkToolConfig releases deployContexts = ToolConfig "/opt/releases" "/opt/etc/deployment" "/opt/var/log/hx-deploy-tool.log" "/opt" "/opt/var/www" "hxdeploytoolcert" "" releases deployContexts DeployMode_select (Prelude.Just (HealthCheckConfig "/health-check" "/"))
+mkToolConfig releases deployContexts = ToolConfig "/opt/releases" "/opt/etc/deployment" "/opt/var/log/hx-deploy-tool.log" "/opt" "/opt/var/www" "hxdeploytoolcert" "" releases deployContexts DeployMode_noproxy (Prelude.Just (HealthCheckConfig "/health-check" "/"))
 
 instance AdlValue ToolConfig where
     atype _ = "config.ToolConfig"
@@ -334,7 +334,7 @@ instance AdlValue ToolConfig where
         <*> parseFieldDef "autoCertContactEmail" ""
         <*> parseField "releases"
         <*> parseField "deployContexts"
-        <*> parseFieldDef "deployMode" DeployMode_select
+        <*> parseFieldDef "deployMode" DeployMode_noproxy
         <*> parseFieldDef "healthCheck" (Prelude.Just (HealthCheckConfig "/health-check" "/"))
 
 data Verbosity

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -48,20 +48,17 @@ import Util(unpackRelease, fetchDeployContext)
 import Commands.ProxyMode.LocalState(nginxConfTemplate)
 
 -- Make the specified release the live release, replacing any existing release.
-select :: T.Text -> IOR ()
-select release = do
+createAndStart :: T.Text -> IOR ()
+createAndStart release = do
   tcfg <- getToolConfig
   case tc_deployMode tcfg of
-    DeployMode_select -> selectNoProxy release
-    _ -> P.select release
+    DeployMode_noproxy -> startNoProxy release
+    _ -> P.createAndStart release
 
-selectNoProxy :: T.Text -> IOR ()
-selectNoProxy release = do
+startNoProxy :: T.Text -> IOR ()
+startNoProxy release = do
   scopeInfo ("Selecting active release " <> release) $ do
     tcfg <- getToolConfig
-    case tc_deployMode tcfg of
-      DeployMode_select -> return ()
-      _ -> error "The select command is not allowed when the proxy is enabled"
     let newReleaseDir = T.unpack (tc_releasesDir tcfg) </> (takeBaseName (T.unpack release))
     let currentReleaseLink = T.unpack (tc_releasesDir tcfg) </> "current"
 

--- a/src/Commands/ProxyMode.hs
+++ b/src/Commands/ProxyMode.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Commands.ProxyMode(
-  select,
   showStatus,
   createAndStart,
   stopAndRemove,
@@ -161,20 +160,6 @@ slaveUpdate_ = do
     sa_update localState (const state)
     label <- getSlaveLabel
     writeSlaveState remoteStateS3 label state
-
--- Make the specified release the live deploy on the endpoint called "main".
--- Any other existing deploy on that endpoint will be shut down
-select  :: T.Text -> IOR ()
-select release = do
-  let endpoint = "main"
-  checkReleaseExists release
-  pm <- getProxyModeConfig
-  origState <- getState
-  createAndStart release
-  connect endpoint release
-  case SM.lookup endpoint (s_connections origState) of
-    Nothing -> return ()
-    Just deployLabel -> when (deployLabel /= release) (stopAndRemove deployLabel)
 
 -- | Allocate an open port in the configured range
 allocatePort :: ProxyModeConfig -> State -> IO Word32

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -43,11 +43,9 @@ main = do
     ["expand-template", templatePath, destPath] -> runWithConfigAndLog (U.injectContext id templatePath destPath)
     ["aws-docker-login-cmd"]                    -> runWithConfigAndLog (C.awsDockerLoginCmd)
  
-    ["select", release]                         -> runWithConfigAndLog (C.select (T.pack release))
-
     ["status"]                                  -> runWithConfig       (P.showStatus False)
     ["status", "--show-slaves"]                 -> runWithConfig       (P.showStatus True)
-    ["start", release]                          -> runWithConfigAndLog (P.createAndStart (T.pack release))
+    ["start", release]                          -> runWithConfigAndLog (C.createAndStart (T.pack release))
     ["stop", deploy]                            -> runWithConfigAndLog (P.stopAndRemove (T.pack deploy))
     ["connect", endpoint, deploy]               -> runWithConfigAndLog (P.connect (T.pack endpoint) (T.pack deploy))
     ["disconnect", endpoint]                    -> runWithConfigAndLog (P.disconnect (T.pack endpoint))


### PR DESCRIPTION
....  remove the select subcommand from the cli and made the start command do the right thing when a proxy is not configured.

This replaces #23 