### PR TITLE
Rename releases directory to deploys

### DIFF
--- a/adl/config.adl
+++ b/adl/config.adl
@@ -11,8 +11,8 @@ import sys.types.Maybe;
 
 /// Configuration file for the deployment tool
 struct ToolConfig {
-    FilePath releasesDir = "/opt/releases";
-    FilePath contextCache = "/opt/etc/deployment";
+    FilePath deploysDir = "/opt/deploys";
+    FilePath contextCache = "/opt/config";
     FilePath logFile = "/opt/var/log/camus2.log";
     FilePath letsencryptPrefixDir = "/opt";
     FilePath letsencryptWwwDir = "/opt/var/www";

--- a/src/ADL/Config.hs
+++ b/src/ADL/Config.hs
@@ -267,7 +267,7 @@ instance AdlValue SslCertPaths where
         <*> parseField "sslCertificateKey"
 
 data ToolConfig = ToolConfig
-    { tc_releasesDir :: ADL.Types.FilePath
+    { tc_deploysDir :: ADL.Types.FilePath
     , tc_contextCache :: ADL.Types.FilePath
     , tc_logFile :: ADL.Types.FilePath
     , tc_letsencryptPrefixDir :: ADL.Types.FilePath
@@ -282,13 +282,13 @@ data ToolConfig = ToolConfig
     deriving (Prelude.Eq,Prelude.Ord,Prelude.Show)
 
 mkToolConfig :: BlobStoreConfig -> ToolConfig
-mkToolConfig releases = ToolConfig "/opt/releases" "/opt/etc/deployment" "/opt/var/log/camus2.log" "/opt" "/opt/var/www" "camus2cert" "" releases (stringMapFromList []) DeployMode_noproxy (Prelude.Just (HealthCheckConfig "/health-check" "/"))
+mkToolConfig releases = ToolConfig "/opt/deploys" "/opt/config" "/opt/var/log/camus2.log" "/opt" "/opt/var/www" "camus2cert" "" releases (stringMapFromList []) DeployMode_noproxy (Prelude.Just (HealthCheckConfig "/health-check" "/"))
 
 instance AdlValue ToolConfig where
     atype _ = "config.ToolConfig"
     
     jsonGen = genObject
-        [ genField "releasesDir" tc_releasesDir
+        [ genField "deploysDir" tc_deploysDir
         , genField "contextCache" tc_contextCache
         , genField "logFile" tc_logFile
         , genField "letsencryptPrefixDir" tc_letsencryptPrefixDir
@@ -302,8 +302,8 @@ instance AdlValue ToolConfig where
         ]
     
     jsonParser = ToolConfig
-        <$> parseFieldDef "releasesDir" "/opt/releases"
-        <*> parseFieldDef "contextCache" "/opt/etc/deployment"
+        <$> parseFieldDef "deploysDir" "/opt/deploys"
+        <*> parseFieldDef "contextCache" "/opt/config"
         <*> parseFieldDef "logFile" "/opt/var/log/camus2.log"
         <*> parseFieldDef "letsencryptPrefixDir" "/opt"
         <*> parseFieldDef "letsencryptWwwDir" "/opt/var/www"

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -59,8 +59,8 @@ startNoProxy :: T.Text -> IOR ()
 startNoProxy release = do
   scopeInfo ("Selecting active release " <> release) $ do
     tcfg <- getToolConfig
-    let newReleaseDir = T.unpack (tc_releasesDir tcfg) </> (takeBaseName (T.unpack release))
-    let currentReleaseLink = T.unpack (tc_releasesDir tcfg) </> "current"
+    let newReleaseDir = T.unpack (tc_deploysDir tcfg) </> (takeBaseName (T.unpack release))
+    let currentReleaseLink = T.unpack (tc_deploysDir tcfg) </> "current"
 
     -- Fetch the context in case it has been updated
     fetchConfigContext Nothing
@@ -105,8 +105,8 @@ stopDeploy deploy = do
 stopNoProxy :: T.Text -> IOR ()
 stopNoProxy deploy = do
   tcfg <- getToolConfig
-  --let newReleaseDir = T.unpack (tc_releasesDir tcfg) </> (takeBaseName (T.unpack deploy))
-  let currentReleaseLink = T.unpack (tc_releasesDir tcfg) </> "current"
+  --let newReleaseDir = T.unpack (tc_deploysDir tcfg) </> (takeBaseName (T.unpack deploy))
+  let currentReleaseLink = T.unpack (tc_deploysDir tcfg) </> "current"
   currentExists <- liftIO $ doesDirectoryExist currentReleaseLink
   scopeInfo ("Stopping active deployment " <> deploy) $ liftIO $ do
     when currentExists $ do

--- a/src/Commands/ProxyMode/LocalState.hs
+++ b/src/Commands/ProxyMode/LocalState.hs
@@ -118,7 +118,7 @@ executeAction (CreateDeploy d) = do
     tcfg <- getToolConfig
     pm <- getProxyModeConfig
     fetchConfigContext Nothing
-    let deployDir = T.unpack (tc_releasesDir tcfg) </> (takeBaseName (T.unpack (d_release d)))
+    let deployDir = T.unpack (tc_deploysDir tcfg) </> (takeBaseName (T.unpack (d_release d)))
     liftIO $ createDirectoryIfMissing True deployDir
     unpackRelease (contextWithLocalPorts pm (d_port d)) (d_release d) deployDir
 
@@ -130,7 +130,7 @@ executeAction (CreateDeploy d) = do
 executeAction (DestroyDeploy d) = do
   scopeInfo "execute DestroyDeploy" $ do
     tcfg <- getToolConfig
-    let deployDir = T.unpack (tc_releasesDir tcfg) </> (takeBaseName (T.unpack (d_release d)))
+    let deployDir = T.unpack (tc_deploysDir tcfg) </> (takeBaseName (T.unpack (d_release d)))
     rcfg <- getReleaseConfig deployDir
     scopeInfo "running stop script" $ callCommandInDir deployDir (rc_stopCommand rcfg)
     scopeInfo "removing directory" $ liftIO $ removeDirectoryRecursive deployDir
@@ -163,7 +163,7 @@ getState = do
 getProxyDir :: IOR FilePath
 getProxyDir = do
   tcfg <- getToolConfig
-  let proxyDir = T.unpack (tc_releasesDir tcfg) </> "frontend-proxy"
+  let proxyDir = T.unpack (tc_deploysDir tcfg) </> "frontend-proxy"
   liftIO $ createDirectoryIfMissing True proxyDir
   return proxyDir
 


### PR DESCRIPTION
/opt/releases has always been the wrong name. It should have been /opt/deploys.

Given we are changing everything else for v1.0, we might as well fix this also.